### PR TITLE
Fix reasoning effort handling for OpenAI-compatible endpoints

### DIFF
--- a/gpt_oss/responses_api/api_server.py
+++ b/gpt_oss/responses_api/api_server.py
@@ -1,9 +1,10 @@
 import os
+import json
 import datetime
 import uuid
-from typing import Callable, Literal, Optional
+from typing import Any, AsyncGenerator, Callable, Literal, Optional, Union
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from openai_harmony import (
     Author,
@@ -44,10 +45,16 @@ from .events import (
     ResponseWebSearchCallSearching,
 )
 from .types import (
+    BrowserToolConfig,
     CodeInterpreterCallItem,
+    CodeInterpreterToolConfig,
     Error,
     FunctionCallItem,
+    FunctionCallOutputItem,
+    FunctionToolDefinition,
     Item,
+    MODEL_IDENTIFIER,
+    ReasoningConfig,
     ReasoningItem,
     ReasoningTextContentItem,
     ResponseObject,
@@ -64,13 +71,19 @@ from .types import (
 DEFAULT_TEMPERATURE = 0.0
 
 
-def get_reasoning_effort(effort: Literal["low", "medium", "high"]) -> ReasoningEffort:
-    if effort == "low":
-        return ReasoningEffort.LOW
-    if effort == "medium":
-        return ReasoningEffort.MEDIUM
-    if effort == "high":
-        return ReasoningEffort.HIGH
+def get_reasoning_effort(
+    effort: Union[Literal["low", "medium", "high"], ReasoningEffort]
+) -> ReasoningEffort:
+    if isinstance(effort, ReasoningEffort):
+        return effort
+    if isinstance(effort, str):
+        normalized = effort.lower()
+        if normalized == "low":
+            return ReasoningEffort.LOW
+        if normalized == "medium":
+            return ReasoningEffort.MEDIUM
+        if normalized == "high":
+            return ReasoningEffort.HIGH
     raise ValueError(f"Invalid reasoning effort: {effort}")
 
 
@@ -83,10 +96,831 @@ def is_not_builtin_tool(recipient: str) -> bool:
 
 
 def create_api_server(
-    infer_next_token: Callable[[list[int], float], int], encoding: HarmonyEncoding
+    infer_next_token: Callable[[list[int], float], int],
+    encoding: HarmonyEncoding,
+    model_id: Optional[str] = None,
 ) -> FastAPI:
     app = FastAPI()
     responses_store: dict[str, tuple[ResponsesRequest, ResponseObject]] = {}
+    reported_model_id = model_id or MODEL_IDENTIFIER
+
+    def _maybe_override_model_id(body: ResponsesRequest) -> None:
+        if body.model in (None, "", MODEL_IDENTIFIER):
+            body.model = reported_model_id
+
+    def _normalize_message_content(content: Any) -> str:
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            text_parts: list[str] = []
+            for part in content:
+                if isinstance(part, dict):
+                    part_type = part.get("type")
+                    if part_type in {"text", "input_text", "output_text"}:
+                        text_parts.append(str(part.get("text", "")))
+                    elif part_type == "tool_result":
+                        if isinstance(part.get("content"), str):
+                            text_parts.append(part["content"])
+                        elif "text" in part:
+                            text_parts.append(str(part["text"]))
+                        elif "result" in part:
+                            text_parts.append(json.dumps(part["result"]))
+                    elif part_type in {"image_url", "image"}:
+                        raise HTTPException(
+                            status_code=400,
+                            detail="Image content is not supported by this server.",
+                        )
+                    elif "text" in part:
+                        text_parts.append(str(part.get("text", "")))
+                else:
+                    text_parts.append(str(part))
+            return "".join(text_parts)
+        return str(content)
+
+    def _ensure_function_arguments(arguments: Any) -> str:
+        if arguments is None:
+            return ""
+        if isinstance(arguments, str):
+            return arguments
+        return json.dumps(arguments)
+
+    def _convert_tool_definitions(tools_payload: Any) -> list[
+        FunctionToolDefinition | BrowserToolConfig | CodeInterpreterToolConfig
+    ]:
+        converted: list[
+            FunctionToolDefinition | BrowserToolConfig | CodeInterpreterToolConfig
+        ] = []
+        if not isinstance(tools_payload, list):
+            return converted
+        for tool in tools_payload:
+            if not isinstance(tool, dict):
+                continue
+            tool_type = tool.get("type")
+            if tool_type == "function" and isinstance(tool.get("function"), dict):
+                fn = tool["function"]
+                name = fn.get("name")
+                if not name:
+                    continue
+                description = fn.get("description", "")
+                parameters = fn.get("parameters") or {}
+                strict = bool(tool.get("strict", fn.get("strict", False)))
+                converted.append(
+                    FunctionToolDefinition(
+                        type="function",
+                        name=name,
+                        description=description,
+                        parameters=parameters,
+                        strict=strict,
+                    )
+                )
+            elif tool_type == "browser_search":
+                converted.append(BrowserToolConfig(type="browser_search"))
+            elif tool_type == "code_interpreter":
+                converted.append(CodeInterpreterToolConfig(type="code_interpreter"))
+        return converted
+
+    def _convert_chat_request(
+        payload: dict[str, Any]
+    ) -> tuple[ResponsesRequest, bool, bool]:
+        if not isinstance(payload, dict):
+            raise HTTPException(
+                status_code=400, detail="Request body must be a JSON object."
+            )
+
+        n_value = payload.get("n", 1)
+        try:
+            if int(n_value) != 1:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Only n=1 is supported for chat completions.",
+                )
+        except (TypeError, ValueError):
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid value for 'n' in chat completions request.",
+            )
+
+        messages = payload.get("messages")
+        if not isinstance(messages, list) or len(messages) == 0:
+            raise HTTPException(
+                status_code=400,
+                detail="The 'messages' field must be a non-empty list.",
+            )
+
+        stream = bool(payload.get("stream", False))
+        stream_options = payload.get("stream_options") or {}
+        include_usage = bool(stream_options.get("include_usage"))
+
+        instructions_parts: list[str] = []
+        input_items: list[
+            Item | FunctionCallItem | FunctionCallOutputItem | ReasoningItem
+        ] = []
+
+        for message in messages:
+            if not isinstance(message, dict):
+                raise HTTPException(
+                    status_code=400,
+                    detail="Each message must be an object with role and content.",
+                )
+            role = message.get("role")
+            content = message.get("content")
+
+            if role == "system":
+                instructions_parts.append(_normalize_message_content(content))
+                continue
+
+            if role == "user":
+                text_content = _normalize_message_content(content)
+                input_items.append(Item(role="user", content=text_content))
+                continue
+
+            if role == "assistant":
+                text_content = _normalize_message_content(content)
+                if text_content:
+                    input_items.append(Item(role="assistant", content=text_content))
+
+                tool_calls_data: list[dict[str, Any]] = []
+                message_tool_calls = message.get("tool_calls")
+                if isinstance(message_tool_calls, list):
+                    tool_calls_data.extend(
+                        tc for tc in message_tool_calls if isinstance(tc, dict)
+                    )
+
+                function_call = message.get("function_call")
+                if isinstance(function_call, dict) and function_call.get("name"):
+                    tool_calls_data.append(
+                        {
+                            "id": message.get("id"),
+                            "type": "function",
+                            "function": function_call,
+                        }
+                    )
+
+                for tool_call in tool_calls_data:
+                    fn = tool_call.get("function") or {}
+                    name = fn.get("name")
+                    if not name:
+                        continue
+                    call_id = tool_call.get("id") or f"call_{uuid.uuid4().hex}"
+                    arguments = _ensure_function_arguments(fn.get("arguments"))
+                    input_items.append(
+                        FunctionCallItem(
+                            name=name,
+                            arguments=arguments,
+                            call_id=call_id,
+                            id=call_id,
+                        )
+                    )
+                continue
+
+            if role in {"tool", "function"}:
+                tool_call_id = (
+                    message.get("tool_call_id")
+                    or message.get("id")
+                    or message.get("name")
+                )
+                if not tool_call_id:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Tool messages must specify 'tool_call_id'.",
+                    )
+                output_text = _normalize_message_content(content)
+                input_items.append(
+                    FunctionCallOutputItem(call_id=tool_call_id, output=output_text)
+                )
+                continue
+
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported message role '{role}'.",
+            )
+
+        if not input_items:
+            raise HTTPException(
+                status_code=400,
+                detail="At least one non-system message must be provided.",
+            )
+
+        instructions = "\n".join(
+            part for part in instructions_parts if part and part.strip()
+        )
+        instructions = instructions or None
+
+        tool_definitions = _convert_tool_definitions(payload.get("tools"))
+
+        tool_choice_param = payload.get("tool_choice")
+        mapped_tool_choice: Optional[str] = None
+        if isinstance(tool_choice_param, str):
+            if tool_choice_param in {"auto", "none"}:
+                mapped_tool_choice = tool_choice_param
+        elif isinstance(tool_choice_param, dict):
+            choice_type = tool_choice_param.get("type")
+            if choice_type in {"auto", "none"}:
+                mapped_tool_choice = choice_type
+            elif choice_type == "function":
+                mapped_tool_choice = "auto"
+
+        reasoning_param = payload.get("reasoning")
+        reasoning_config: Optional[ReasoningConfig] = None
+        if isinstance(reasoning_param, dict):
+            effort = reasoning_param.get("effort")
+            if effort in {"low", "medium", "high"}:
+                reasoning_config = ReasoningConfig(effort=effort)
+
+        metadata_param = payload.get("metadata")
+        metadata_dict = metadata_param if isinstance(metadata_param, dict) else {}
+
+        request_kwargs: dict[str, Any] = {
+            "instructions": instructions,
+            "input": input_items,
+            "tools": tool_definitions,
+            "model": payload.get("model"),
+            "stream": stream,
+            "temperature": payload.get("temperature"),
+            "tool_choice": mapped_tool_choice,
+            "parallel_tool_calls": payload.get("parallel_tool_calls"),
+            "metadata": metadata_dict,
+        }
+        max_tokens_param = payload.get("max_tokens")
+        if max_tokens_param is not None:
+            request_kwargs["max_output_tokens"] = max_tokens_param
+        if reasoning_config is not None:
+            request_kwargs["reasoning"] = reasoning_config
+
+        responses_request = ResponsesRequest(**request_kwargs)
+        return responses_request, stream, include_usage
+
+    def _convert_completion_request(
+        payload: dict[str, Any]
+    ) -> tuple[ResponsesRequest, bool, bool]:
+        if not isinstance(payload, dict):
+            raise HTTPException(
+                status_code=400, detail="Request body must be a JSON object."
+            )
+
+        n_value = payload.get("n", 1)
+        try:
+            if int(n_value) != 1:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Only n=1 is supported for completions.",
+                )
+        except (TypeError, ValueError):
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid value for 'n' in completions request.",
+            )
+
+        prompt = payload.get("prompt")
+        if isinstance(prompt, list):
+            prompt_text = "".join(str(item) for item in prompt)
+        elif isinstance(prompt, str):
+            prompt_text = prompt
+        else:
+            raise HTTPException(
+                status_code=400, detail="The 'prompt' field must be provided."
+            )
+
+        stream = bool(payload.get("stream", False))
+        stream_options = payload.get("stream_options") or {}
+        include_usage = bool(stream_options.get("include_usage"))
+
+        request_kwargs: dict[str, Any] = {
+            "instructions": None,
+            "input": [Item(role="user", content=prompt_text)],
+            "model": payload.get("model"),
+            "stream": stream,
+            "temperature": payload.get("temperature"),
+            "metadata": payload.get("metadata")
+            if isinstance(payload.get("metadata"), dict)
+            else {},
+        }
+
+        max_tokens_param = payload.get("max_tokens")
+        if max_tokens_param is not None:
+            request_kwargs["max_output_tokens"] = max_tokens_param
+
+        responses_request = ResponsesRequest(**request_kwargs)
+        return responses_request, stream, include_usage
+
+    def _collect_response_parts(
+        response: ResponseObject,
+    ) -> tuple[Optional[str], list[dict[str, Any]], Optional[str]]:
+        text_parts: list[str] = []
+        tool_calls: list[dict[str, Any]] = []
+        reasoning_parts: list[str] = []
+
+        for item in response.output:
+            if isinstance(item, Item) and item.role == "assistant":
+                if isinstance(item.content, list):
+                    for content_item in item.content:
+                        if hasattr(content_item, "text") and content_item.text:
+                            text_parts.append(content_item.text)
+                elif isinstance(item.content, str):
+                    text_parts.append(item.content)
+            elif isinstance(item, FunctionCallItem):
+                tool_calls.append(
+                    {
+                        "id": item.call_id,
+                        "type": "function",
+                        "function": {
+                            "name": item.name,
+                            "arguments": item.arguments,
+                        },
+                    }
+                )
+            elif isinstance(item, ReasoningItem) and item.content:
+                reasoning_parts.extend(
+                    part.text for part in item.content if hasattr(part, "text")
+                )
+
+        text = "".join(text_parts) if text_parts else None
+        reasoning_text = "\n".join(reasoning_parts).strip() if reasoning_parts else None
+        return text, tool_calls, reasoning_text
+
+    def _build_usage_dict(usage: Optional[Usage]) -> Optional[dict[str, int]]:
+        if usage is None:
+            return None
+        return {
+            "prompt_tokens": usage.input_tokens,
+            "completion_tokens": usage.output_tokens,
+            "total_tokens": usage.total_tokens,
+        }
+
+    def _resolve_finish_reason(
+        text: Optional[str], tool_calls: list[dict[str, Any]]
+    ) -> str:
+        if tool_calls and not (text and text.strip()):
+            return "tool_calls"
+        return "stop"
+
+    def _format_chat_completion_id(response_id: str) -> str:
+        if response_id.startswith("resp_"):
+            return f"chatcmpl-{response_id[len('resp_') :]}"
+        return response_id
+
+    def _format_completion_id(response_id: str) -> str:
+        if response_id.startswith("resp_"):
+            return f"cmpl-{response_id[len('resp_') :]}"
+        return response_id
+
+    def _build_chat_completion_response(
+        response: ResponseObject, model_name: str
+    ) -> dict[str, Any]:
+        if response.error is not None:
+            raise HTTPException(status_code=500, detail=response.error.message)
+
+        text, tool_calls, reasoning_text = _collect_response_parts(response)
+        finish_reason = _resolve_finish_reason(text, tool_calls)
+
+        message: dict[str, Any] = {
+            "role": "assistant",
+            "content": text,
+        }
+        if tool_calls:
+            message["tool_calls"] = tool_calls
+        if reasoning_text:
+            message["reasoning"] = reasoning_text
+            message["reasoning_content"] = reasoning_text
+
+        response_id = response.id or f"resp_{uuid.uuid4().hex}"
+
+        payload = {
+            "id": _format_chat_completion_id(response_id),
+            "object": "chat.completion",
+            "created": response.created_at,
+            "model": model_name,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": message,
+                    "finish_reason": finish_reason,
+                    "logprobs": None,
+                }
+            ],
+        }
+
+        usage_dict = _build_usage_dict(response.usage)
+        if usage_dict is not None:
+            payload["usage"] = usage_dict
+
+        return payload
+
+    def _build_completion_response(
+        response: ResponseObject, model_name: str
+    ) -> dict[str, Any]:
+        if response.error is not None:
+            raise HTTPException(status_code=500, detail=response.error.message)
+
+        text, tool_calls, _ = _collect_response_parts(response)
+        completion_text = text or ""
+        finish_reason = _resolve_finish_reason(text, tool_calls)
+        response_id = response.id or f"resp_{uuid.uuid4().hex}"
+
+        payload = {
+            "id": _format_completion_id(response_id),
+            "object": "text_completion",
+            "created": response.created_at,
+            "model": model_name,
+            "choices": [
+                {
+                    "index": 0,
+                    "text": completion_text,
+                    "logprobs": None,
+                    "finish_reason": finish_reason,
+                }
+            ],
+        }
+
+        usage_dict = _build_usage_dict(response.usage)
+        if usage_dict is not None:
+            payload["usage"] = usage_dict
+
+        return payload
+
+    def _format_sse(payload: dict[str, Any]) -> str:
+        return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
+
+    def _build_chat_chunk(
+        response_id: str,
+        model_name: str,
+        created: int,
+        delta: dict[str, Any],
+        *,
+        finish_reason: Optional[str] = None,
+        usage: Optional[dict[str, int]] = None,
+    ) -> dict[str, Any]:
+        chunk: dict[str, Any] = {
+            "id": _format_chat_completion_id(response_id),
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": model_name,
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": delta,
+                    "logprobs": None,
+                    "finish_reason": finish_reason,
+                }
+            ],
+        }
+        if usage is not None:
+            chunk["usage"] = usage
+        return chunk
+
+    def _build_completion_chunk(
+        response_id: str,
+        model_name: str,
+        created: int,
+        text_delta: str,
+        *,
+        finish_reason: Optional[str] = None,
+        usage: Optional[dict[str, int]] = None,
+    ) -> dict[str, Any]:
+        chunk: dict[str, Any] = {
+            "id": _format_completion_id(response_id),
+            "object": "text_completion.chunk",
+            "created": created,
+            "model": model_name,
+            "choices": [
+                {
+                    "index": 0,
+                    "text": text_delta,
+                    "logprobs": None,
+                    "finish_reason": finish_reason,
+                }
+            ],
+        }
+        if usage is not None:
+            chunk["usage"] = usage
+        return chunk
+
+    def _prepare_event_stream(
+        body: ResponsesRequest,
+        request: Optional[Request],
+        *,
+        stream_override: Optional[bool] = None,
+        as_sse_override: Optional[bool] = None,
+        store_response: bool = True,
+    ) -> tuple["StreamResponsesEvents", bool, str]:
+        print("request received")
+
+        _maybe_override_model_id(body)
+
+        use_browser_tool = any(
+            getattr(tool, "type", None) == "browser_search"
+            for tool in (body.tools or [])
+        )
+        use_code_interpreter = any(
+            getattr(tool, "type", None) == "code_interpreter"
+            for tool in (body.tools or [])
+        )
+
+        if use_browser_tool:
+            tool_backend = os.getenv("BROWSER_BACKEND", "exa")
+            if tool_backend == "youcom":
+                backend = YouComBackend(source="web")
+            elif tool_backend == "exa":
+                backend = ExaBackend(source="web")
+            else:
+                raise ValueError(f"Invalid tool backend: {tool_backend}")
+            browser_tool: Optional[SimpleBrowserTool] = SimpleBrowserTool(backend=backend)
+        else:
+            browser_tool = None
+
+        if use_code_interpreter:
+            python_tool: Optional[PythonTool] = PythonTool()
+        else:
+            python_tool = None
+
+        if body.previous_response_id:
+            prev = responses_store.get(body.previous_response_id)
+            if prev:
+                prev_req, prev_resp = prev
+
+                def _ensure_list(inp):
+                    if isinstance(inp, str):
+                        return [
+                            Item(
+                                type="message",
+                                role="user",
+                                content=[TextContentItem(type="input_text", text=inp)],
+                            )
+                        ]
+                    return list(inp)
+
+                merged_input = _ensure_list(prev_req.input) + list(prev_resp.output)
+                merged_input.extend(_ensure_list(body.input))
+
+                if body.instructions is None:
+                    body.instructions = prev_req.instructions
+                body.input = merged_input
+
+        system_message_content = SystemContent.new().with_conversation_start_date(
+            datetime.datetime.now().strftime("%Y-%m-%d")
+        )
+
+        if body.reasoning is not None:
+            try:
+                reasoning_effort = get_reasoning_effort(body.reasoning.effort)
+            except ValueError as e:
+                raise HTTPException(status_code=422, detail=str(e))
+            system_message_content = system_message_content.with_reasoning_effort(
+                reasoning_effort
+            )
+
+        if use_browser_tool:
+            system_message_content = system_message_content.with_tools(
+                browser_tool.tool_config
+            )
+        if use_code_interpreter:
+            system_message_content = system_message_content.with_tools(
+                python_tool.tool_config
+            )
+
+        system_message = Message.from_role_and_content(
+            Role.SYSTEM, system_message_content
+        )
+        messages = [system_message]
+
+        if body.instructions or body.tools:
+            developer_message_content = DeveloperContent.new().with_instructions(
+                body.instructions
+            )
+
+            tools = []
+            for tool in body.tools or []:
+                if getattr(tool, "type", None) == "function":
+                    tools.append(
+                        ToolDescription.new(
+                            tool.name,
+                            tool.description,
+                            tool.parameters,
+                        )
+                    )
+
+            if tools:
+                developer_message_content = developer_message_content.with_function_tools(
+                    tools
+                )
+
+            developer_message = Message.from_role_and_content(
+                Role.DEVELOPER, developer_message_content
+            )
+
+            messages.append(developer_message)
+
+        if isinstance(body.input, str):
+            user_message = Message.from_role_and_content(Role.USER, body.input)
+            messages.append(user_message)
+        else:
+            is_last_message_function_call_output = (
+                len(body.input) > 0 and body.input[-1].type == "function_call_output"
+            )
+            function_call_map: dict[str, FunctionCallItem] = {}
+            last_assistant_idx = -1
+            for idx, item in enumerate(body.input):
+                if item.type == "message" and item.role == Role.ASSISTANT:
+                    last_assistant_idx = idx
+
+            for idx, item in enumerate(body.input):
+                if item.type == "message":
+                    if isinstance(item.content, str):
+                        messages.append(
+                            Message.from_role_and_content(item.role, item.content)
+                        )
+                    else:
+                        for content_item in item.content:
+                            messages.append(
+                                Message.from_role_and_content(
+                                    item.role, content_item.text
+                                )
+                            )
+                    if item.role == Role.ASSISTANT:
+                        messages[-1] = messages[-1].with_channel("final")
+                elif item.type == "reasoning":
+                    if idx > last_assistant_idx and is_last_message_function_call_output:
+                        for content_item in item.content:
+                            messages.append(
+                                Message.from_role_and_content(
+                                    Role.ASSISTANT, content_item.text
+                                ).with_channel("analysis")
+                            )
+                elif item.type == "function_call":
+                    function_call_map[item.call_id] = item
+                    messages.append(
+                        Message.from_role_and_content(Role.ASSISTANT, item.arguments)
+                        .with_recipient(f"functions.{item.name}")
+                        .with_channel("commentary")
+                    )
+                elif item.type == "function_call_output":
+                    function_call = function_call_map.get(item.call_id, None)
+                    if not function_call:
+                        raise ValueError(f"Function call {item.call_id} not found")
+
+                    messages.append(
+                        Message.from_author_and_content(
+                            Author.new(Role.TOOL, f"functions.{function_call.name}"),
+                            item.output,
+                        )
+                        .with_recipient("assistant")
+                        .with_channel("commentary")
+                    )
+
+        conversation = Conversation.from_messages(messages)
+
+        initial_tokens = encoding.render_conversation_for_completion(
+            conversation, Role.ASSISTANT
+        )
+        print(encoding.decode_utf8(initial_tokens))
+        response_id = f"resp_{uuid.uuid4().hex}"
+
+        stream = stream_override if stream_override is not None else bool(body.stream)
+        body.stream = stream
+        as_sse = as_sse_override if as_sse_override is not None else stream
+
+        def store_callback(rid: str, req: ResponsesRequest, resp: ResponseObject):
+            responses_store[rid] = (req, resp)
+
+        event_stream = StreamResponsesEvents(
+            initial_tokens,
+            body,
+            as_sse=as_sse,
+            request=request,
+            response_id=response_id,
+            store_callback=store_callback if store_response and body.store else None,
+            browser_tool=browser_tool,
+            python_tool=python_tool,
+        )
+
+        return event_stream, stream, response_id
+
+    async def _stream_chat_events(
+        event_stream: "StreamResponsesEvents",
+        response_id: str,
+        model_name: str,
+        *,
+        include_usage: bool,
+    ) -> AsyncGenerator[str, None]:
+        created = int(datetime.datetime.now().timestamp())
+        final_response: Optional[ResponseObject] = None
+        first_chunk_sent = False
+        tool_call_index = 0
+
+        async for event in event_stream.run():
+            if isinstance(event, ResponseCreatedEvent):
+                created = event.response.created_at
+                if event.response.id:
+                    response_id = event.response.id
+            elif isinstance(event, ResponseOutputTextDelta):
+                delta_payload = {"content": event.delta}
+                if not first_chunk_sent:
+                    delta_payload["role"] = "assistant"
+                    first_chunk_sent = True
+                chunk = _build_chat_chunk(response_id, model_name, created, delta_payload)
+                yield _format_sse(chunk)
+            elif isinstance(event, ResponseOutputItemDone) and isinstance(
+                event.item, FunctionCallItem
+            ):
+                tool_call = {
+                    "index": tool_call_index,
+                    "id": event.item.call_id,
+                    "type": "function",
+                    "function": {
+                        "name": event.item.name,
+                        "arguments": event.item.arguments,
+                    },
+                }
+                delta_payload = {"tool_calls": [tool_call]}
+                if not first_chunk_sent:
+                    delta_payload["role"] = "assistant"
+                    first_chunk_sent = True
+                chunk = _build_chat_chunk(response_id, model_name, created, delta_payload)
+                yield _format_sse(chunk)
+                tool_call_index += 1
+            elif isinstance(event, ResponseReasoningTextDelta):
+                reasoning_delta = event.delta
+                if reasoning_delta:
+                    delta_payload = {
+                        "reasoning": reasoning_delta,
+                        "reasoning_content": reasoning_delta,
+                    }
+                    if not first_chunk_sent:
+                        delta_payload["role"] = "assistant"
+                        first_chunk_sent = True
+                    chunk = _build_chat_chunk(
+                        response_id, model_name, created, delta_payload
+                    )
+                    yield _format_sse(chunk)
+            elif isinstance(event, ResponseCompletedEvent):
+                final_response = event.response
+                if event.response.id:
+                    response_id = event.response.id
+
+        if final_response is None:
+            return
+
+        text, tool_calls, _ = _collect_response_parts(final_response)
+        finish_reason = _resolve_finish_reason(text, tool_calls)
+        usage = (
+            _build_usage_dict(final_response.usage) if include_usage else None
+        )
+        final_chunk = _build_chat_chunk(
+            response_id,
+            model_name,
+            final_response.created_at,
+            {},
+            finish_reason=finish_reason,
+            usage=usage,
+        )
+        yield _format_sse(final_chunk)
+        yield "data: [DONE]\n\n"
+
+    async def _stream_completion_events(
+        event_stream: "StreamResponsesEvents",
+        response_id: str,
+        model_name: str,
+        *,
+        include_usage: bool,
+    ) -> AsyncGenerator[str, None]:
+        created = int(datetime.datetime.now().timestamp())
+        final_response: Optional[ResponseObject] = None
+
+        async for event in event_stream.run():
+            if isinstance(event, ResponseCreatedEvent):
+                created = event.response.created_at
+                if event.response.id:
+                    response_id = event.response.id
+            elif isinstance(event, ResponseOutputTextDelta):
+                chunk = _build_completion_chunk(
+                    response_id, model_name, created, event.delta
+                )
+                yield _format_sse(chunk)
+            elif isinstance(event, ResponseCompletedEvent):
+                final_response = event.response
+                if event.response.id:
+                    response_id = event.response.id
+
+        if final_response is None:
+            return
+
+        text, tool_calls, _ = _collect_response_parts(final_response)
+        finish_reason = _resolve_finish_reason(text, tool_calls)
+        usage = (
+            _build_usage_dict(final_response.usage) if include_usage else None
+        )
+        final_chunk = _build_completion_chunk(
+            response_id,
+            model_name,
+            final_response.created_at,
+            "",
+            finish_reason=finish_reason,
+            usage=usage,
+        )
+        yield _format_sse(final_chunk)
+        yield "data: [DONE]\n\n"
 
     def generate_response(
         input_tokens: list[int],
@@ -864,7 +1698,11 @@ def create_api_server(
                             break
                     else:
                         raise ValueError("No messages to process")
-                if len(self.output_tokens) >= self.request_body.max_output_tokens:
+                max_output_tokens = self.request_body.max_output_tokens
+                if (
+                    max_output_tokens is not None
+                    and len(self.output_tokens) >= max_output_tokens
+                ):
                     break
 
                 # Adding in the end if we know we are not done
@@ -893,207 +1731,106 @@ def create_api_server(
 
     @app.post("/v1/responses", response_model=ResponseObject)
     async def generate(body: ResponsesRequest, request: Request):
-        print("request received")
-
-        use_browser_tool = any(
-            getattr(tool, "type", None) == "browser_search"
-            for tool in (body.tools or [])
-        )
-        use_code_interpreter = any(
-            getattr(tool, "type", None) == "code_interpreter"
-            for tool in (body.tools or [])
-        )
-
-        if use_browser_tool:
-            tool_backend = os.getenv("BROWSER_BACKEND", "exa")
-            if tool_backend == "youcom":
-                backend = YouComBackend(source="web")
-            elif tool_backend == "exa":
-                backend = ExaBackend(source="web")
-            else:
-                raise ValueError(f"Invalid tool backend: {tool_backend}")
-            browser_tool = SimpleBrowserTool(backend=backend)
-        else:
-            browser_tool = None
-
-        if use_code_interpreter:
-            python_tool = PythonTool()
-        else:
-            python_tool = None
-
-        if body.previous_response_id:
-            prev = responses_store.get(body.previous_response_id)
-            if prev:
-                prev_req, prev_resp = prev
-
-                def _ensure_list(inp):
-                    if isinstance(inp, str):
-                        return [
-                            Item(
-                                type="message",
-                                role="user",
-                                content=[TextContentItem(type="input_text", text=inp)],
-                            )
-                        ]
-                    return list(inp)
-
-                merged_input = _ensure_list(prev_req.input) + list(prev_resp.output)
-                merged_input.extend(_ensure_list(body.input))
-
-                if body.instructions is None:
-                    body.instructions = prev_req.instructions
-                body.input = merged_input
-
-        system_message_content = SystemContent.new().with_conversation_start_date(
-            datetime.datetime.now().strftime("%Y-%m-%d")
-        )
-
-        if body.reasoning is not None:
-            try:
-
-                reasoning_effort = get_reasoning_effort(body.reasoning.effort)
-            except ValueError as e:
-                from fastapi import HTTPException
-
-                raise HTTPException(status_code=422, detail=str(e))
-            system_message_content = system_message_content.with_reasoning_effort(
-                reasoning_effort
-            )
-
-        if use_browser_tool:
-            system_message_content = system_message_content.with_tools(
-                browser_tool.tool_config
-            )
-        if use_code_interpreter:
-            system_message_content = system_message_content.with_tools(
-                python_tool.tool_config
-            )
-
-        system_message = Message.from_role_and_content(
-            Role.SYSTEM, system_message_content
-        )
-        messages = [system_message]
-
-        if body.instructions or body.tools:
-            developer_message_content = DeveloperContent.new().with_instructions(
-                body.instructions
-            )
-
-            tools = []
-            for tool in body.tools:
-                if tool.type == "function":
-                    tools.append(
-                        ToolDescription.new(
-                            tool.name,
-                            tool.description,
-                            tool.parameters,
-                        )
-                    )
-
-            if tools:
-                developer_message_content = (
-                    developer_message_content.with_function_tools(tools)
-                )
-
-            developer_message = Message.from_role_and_content(
-                Role.DEVELOPER, developer_message_content
-            )
-
-            messages.append(developer_message)
-
-        if isinstance(body.input, str):
-            user_message = Message.from_role_and_content(Role.USER, body.input)
-            messages.append(user_message)
-        else:
-            is_last_message_function_call_output = (
-                len(body.input) > 0 and body.input[-1].type == "function_call_output"
-            )
-            function_call_map = {}
-            # Find the index of the last assistant message
-            last_assistant_idx = -1
-            for idx, item in enumerate(body.input):
-                if item.type == "message" and item.role == Role.ASSISTANT:
-                    last_assistant_idx = idx
-
-            for idx, item in enumerate(body.input):
-                if item.type == "message":
-                    # TODO: add system prompt handling
-                    if isinstance(item.content, str):
-                        messages.append(
-                            Message.from_role_and_content(item.role, item.content)
-                        )
-                    else:
-                        for content_item in item.content:
-                            messages.append(
-                                Message.from_role_and_content(
-                                    item.role, content_item.text
-                                )
-                            )
-                    # add final channel to the last assistant message if it's from the assistant
-                    if item.role == Role.ASSISTANT:
-                        messages[-1] = messages[-1].with_channel("final")
-                elif item.type == "reasoning":
-                    # Only include reasoning if it is after the last assistant message and we are handling a function call at the moment
-                    if (
-                        idx > last_assistant_idx
-                        and is_last_message_function_call_output
-                    ):
-                        for content_item in item.content:
-                            messages.append(
-                                Message.from_role_and_content(
-                                    Role.ASSISTANT, content_item.text
-                                ).with_channel("analysis")
-                            )
-                elif item.type == "function_call":
-                    function_call_map[item.call_id] = item
-                    messages.append(
-                        Message.from_role_and_content(Role.ASSISTANT, item.arguments)
-                        .with_recipient(f"functions.{item.name}")
-                        .with_channel("commentary")
-                    )
-                elif item.type == "function_call_output":
-                    function_call = function_call_map.get(item.call_id, None)
-                    if not function_call:
-                        raise ValueError(f"Function call {item.call_id} not found")
-
-                    messages.append(
-                        Message.from_author_and_content(
-                            Author.new(Role.TOOL, f"functions.{function_call.name}"),
-                            item.output,
-                        )
-                        .with_recipient("assistant")
-                        .with_channel("commentary")
-                    )
-
-        conversation = Conversation.from_messages(messages)
-
-        initial_tokens = encoding.render_conversation_for_completion(
-            conversation, Role.ASSISTANT
-        )
-        print(encoding.decode_utf8(initial_tokens))
-        response_id = f"resp_{uuid.uuid4().hex}"
-
-        def store_callback(rid: str, req: ResponsesRequest, resp: ResponseObject):
-            responses_store[rid] = (req, resp)
-
-        event_stream = StreamResponsesEvents(
-            initial_tokens,
-            body,
-            as_sse=body.stream,
-            request=request,
-            response_id=response_id,
-            store_callback=store_callback,
-            browser_tool=browser_tool,
-            python_tool=python_tool,
-        )
-
-        if body.stream:
+        event_stream, stream, _ = _prepare_event_stream(body, request)
+        if stream:
             return StreamingResponse(event_stream.run(), media_type="text/event-stream")
-        else:
-            last_event = None
-            async for event in event_stream.run():
-                last_event = event
 
-            return last_event.response
+        final_event: Optional[ResponseCompletedEvent] = None
+        async for event in event_stream.run():
+            if isinstance(event, ResponseCompletedEvent):
+                final_event = event
+
+        if final_event is None:
+            raise HTTPException(status_code=500, detail="No response generated")
+
+        return final_event.response
+
+    @app.get("/v1/models")
+    async def list_models() -> dict[str, Any]:
+        return {
+            "object": "list",
+            "data": [
+                {
+                    "id": reported_model_id,
+                    "object": "model",
+                    "created": 0,
+                    "owned_by": "gpt-oss",
+                }
+            ],
+        }
+
+    @app.post("/v1/chat/completions")
+    async def create_chat_completion(request: Request) -> Any:
+        payload = await request.json()
+        responses_request, stream, include_usage = _convert_chat_request(payload)
+        event_stream, _, response_id = _prepare_event_stream(
+            responses_request,
+            request,
+            stream_override=stream,
+            as_sse_override=False,
+            store_response=False,
+        )
+
+        model_name = responses_request.model or reported_model_id
+
+        if stream:
+            async def chat_event_generator() -> AsyncGenerator[str, None]:
+                async for chunk in _stream_chat_events(
+                    event_stream,
+                    response_id,
+                    model_name,
+                    include_usage=include_usage,
+                ):
+                    yield chunk
+
+            return StreamingResponse(chat_event_generator(), media_type="text/event-stream")
+
+        final_response: Optional[ResponseObject] = None
+        async for event in event_stream.run():
+            if isinstance(event, ResponseCompletedEvent):
+                final_response = event.response
+
+        if final_response is None:
+            raise HTTPException(status_code=500, detail="No response generated")
+
+        return _build_chat_completion_response(final_response, model_name)
+
+    @app.post("/v1/completions")
+    async def create_completion(request: Request) -> Any:
+        payload = await request.json()
+        responses_request, stream, include_usage = _convert_completion_request(payload)
+        event_stream, _, response_id = _prepare_event_stream(
+            responses_request,
+            request,
+            stream_override=stream,
+            as_sse_override=False,
+            store_response=False,
+        )
+
+        model_name = responses_request.model or reported_model_id
+
+        if stream:
+            async def completion_event_generator() -> AsyncGenerator[str, None]:
+                async for chunk in _stream_completion_events(
+                    event_stream,
+                    response_id,
+                    model_name,
+                    include_usage=include_usage,
+                ):
+                    yield chunk
+
+            return StreamingResponse(
+                completion_event_generator(), media_type="text/event-stream"
+            )
+
+        final_response: Optional[ResponseObject] = None
+        async for event in event_stream.run():
+            if isinstance(event, ResponseCompletedEvent):
+                final_response = event.response
+
+        if final_response is None:
+            raise HTTPException(status_code=500, detail="No response generated")
+
+        return _build_completion_response(final_response, model_name)
 
     return app

--- a/gpt_oss/responses_api/serve.py
+++ b/gpt_oss/responses_api/serve.py
@@ -35,6 +35,13 @@ if __name__ == "__main__":
         # default to metal on macOS, triton on other platforms
         default="metal" if __import__("platform").system() == "Darwin" else "triton",
     )
+    parser.add_argument(
+        "--model-id",
+        metavar="MODEL",
+        type=str,
+        default=None,
+        help="Model identifier to report via the API",
+    )
     args = parser.parse_args()
 
     if args.inference_backend == "triton":
@@ -55,4 +62,7 @@ if __name__ == "__main__":
     encoding = load_harmony_encoding(HarmonyEncodingName.HARMONY_GPT_OSS)
 
     infer_next_token = setup_model(args.checkpoint)
-    uvicorn.run(create_api_server(infer_next_token, encoding), port=args.port)
+    uvicorn.run(
+        create_api_server(infer_next_token, encoding, model_id=args.model_id),
+        port=args.port,
+    )

--- a/gpt_oss/responses_api/types.py
+++ b/gpt_oss/responses_api/types.py
@@ -1,11 +1,12 @@
 from typing import Any, Dict, Literal, Optional, Union
 
-from openai_harmony import ReasoningEffort
 from pydantic import BaseModel
 
 MODEL_IDENTIFIER = "gpt-oss-120b"
 DEFAULT_TEMPERATURE = 0.0
-REASONING_EFFORT = ReasoningEffort.LOW
+# Reasoning effort defaults to the string value that OpenAI's API expects.
+# (The Harmony conversion layer will map this to ``ReasoningEffort.LOW``.)
+REASONING_EFFORT = "low"
 DEFAULT_MAX_OUTPUT_TOKENS = 131072
 
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -228,3 +228,118 @@ class TestUsageTracking:
         
         # Longer input should use more tokens
         assert usage2["input_tokens"] > usage1["input_tokens"]
+
+
+class TestModelsEndpoint:
+
+    def test_models_list(self, api_client):
+        response = api_client.get("/v1/models")
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["object"] == "list"
+        assert isinstance(data["data"], list)
+        assert data["data"][0]["id"] == "gpt-oss-120b"
+
+
+class TestChatCompletionsEndpoint:
+
+    def _chat_payload(self):
+        return {
+            "model": "gpt-oss-120b",
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Say hello"},
+            ],
+        }
+
+    def test_basic_chat_completion(self, api_client):
+        payload = self._chat_payload()
+        response = api_client.post("/v1/chat/completions", json=payload)
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["object"] == "chat.completion"
+        assert data["choices"][0]["message"]["role"] == "assistant"
+        assert "Test response" in (data["choices"][0]["message"].get("content") or "")
+
+    def test_chat_completion_streaming(self, api_client):
+        payload = self._chat_payload()
+        payload["stream"] = True
+        with api_client.stream("POST", "/v1/chat/completions", json=payload) as response:
+            assert response.status_code == status.HTTP_200_OK
+            for line in response.iter_lines():
+                if line and line.startswith("data: "):
+                    chunk = line[6:]
+                    if chunk == "[DONE]":
+                        break
+                    json.loads(chunk)
+                    break
+
+    def test_chat_completion_streaming_null_max_tokens(self, api_client):
+        payload = self._chat_payload()
+        payload["stream"] = True
+        payload["max_tokens"] = None
+        with api_client.stream("POST", "/v1/chat/completions", json=payload) as response:
+            assert response.status_code == status.HTTP_200_OK
+            for line in response.iter_lines():
+                if line and line.startswith("data: "):
+                    chunk = line[6:]
+                    if chunk == "[DONE]":
+                        break
+                    json.loads(chunk)
+                    break
+
+    def test_chat_completion_invalid_n(self, api_client):
+        payload = self._chat_payload()
+        payload["n"] = 2
+        response = api_client.post("/v1/chat/completions", json=payload)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+class TestCompletionsEndpoint:
+
+    def _completion_payload(self):
+        return {
+            "model": "gpt-oss-120b",
+            "prompt": "Hello there",
+        }
+
+    def test_basic_completion(self, api_client):
+        payload = self._completion_payload()
+        response = api_client.post("/v1/completions", json=payload)
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["object"] == "text_completion"
+        assert "Test response" in data["choices"][0]["text"]
+
+    def test_completion_streaming(self, api_client):
+        payload = self._completion_payload()
+        payload["stream"] = True
+        with api_client.stream("POST", "/v1/completions", json=payload) as response:
+            assert response.status_code == status.HTTP_200_OK
+            for line in response.iter_lines():
+                if line and line.startswith("data: "):
+                    chunk = line[6:]
+                    if chunk == "[DONE]":
+                        break
+                    json.loads(chunk)
+                    break
+
+    def test_completion_streaming_null_max_tokens(self, api_client):
+        payload = self._completion_payload()
+        payload["stream"] = True
+        payload["max_tokens"] = None
+        with api_client.stream("POST", "/v1/completions", json=payload) as response:
+            assert response.status_code == status.HTTP_200_OK
+            for line in response.iter_lines():
+                if line and line.startswith("data: "):
+                    chunk = line[6:]
+                    if chunk == "[DONE]":
+                        break
+                    json.loads(chunk)
+                    break
+
+    def test_completion_invalid_n(self, api_client):
+        payload = self._completion_payload()
+        payload["n"] = 3
+        response = api_client.post("/v1/completions", json=payload)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/test_responses_api_reasoning.py
+++ b/tests/test_responses_api_reasoning.py
@@ -1,0 +1,20 @@
+from openai_harmony import ReasoningEffort
+
+from gpt_oss.responses_api.api_server import get_reasoning_effort
+from gpt_oss.responses_api.types import ReasoningConfig
+
+
+def test_reasoning_config_default_uses_string_literal():
+    config = ReasoningConfig()
+    assert isinstance(config.effort, str)
+    assert config.effort == "low"
+
+
+def test_get_reasoning_effort_accepts_string_literal():
+    result = get_reasoning_effort("medium")
+    assert result is ReasoningEffort.MEDIUM
+
+
+def test_get_reasoning_effort_accepts_enum_instance():
+    result = get_reasoning_effort(ReasoningEffort.HIGH)
+    assert result is ReasoningEffort.HIGH


### PR DESCRIPTION
## Summary
- extend the responses API server with reusable request/stream helpers and OpenAI-style chat/completions payload converters
- expose `/v1/models`, `/v1/chat/completions`, and `/v1/completions` alongside a configurable model identifier for the CLI launcher
- expand API tests to cover the new endpoints and error handling for unsupported options
- ensure reasoning effort defaults remain OpenAI-compatible, accept Harmony enum inputs, and add regression tests to lock the behavior down
- treat missing or null `max_tokens` values as "use the default limit" and guard the streaming loop so OpenAI-style clients that omit the field no longer trigger runtime errors

## Testing
- ⚠️ `pytest tests/test_api_endpoints.py::TestChatCompletionsEndpoint::test_chat_completion_streaming_null_max_tokens` *(fails: HarmonyError downloading HarmonyGptOss vocab in the offline test environment)*
- ⚠️ `pytest tests/test_api_endpoints.py::TestChatCompletionsEndpoint::test_basic_chat_completion` *(fails: HarmonyError downloading HarmonyGptOss vocab in the offline test environment)*
- ✅ `pytest tests/test_responses_api_reasoning.py`


------
https://chatgpt.com/codex/tasks/task_e_68c8fe1366a08322826b5cefdc036fb1