### PR TITLE
Fix missing type defaults for function call items

### DIFF
--- a/gpt_oss/responses_api/types.py
+++ b/gpt_oss/responses_api/types.py
@@ -51,7 +51,7 @@ class Item(BaseModel):
 
 
 class FunctionCallItem(BaseModel):
-    type: Literal["function_call"]
+    type: Literal["function_call"] = "function_call"
     name: str
     arguments: str
     status: Literal["in_progress", "completed", "incomplete"] = "completed"
@@ -60,7 +60,7 @@ class FunctionCallItem(BaseModel):
 
 
 class FunctionCallOutputItem(BaseModel):
-    type: Literal["function_call_output"]
+    type: Literal["function_call_output"] = "function_call_output"
     call_id: str = "call_1234"
     output: str
 


### PR DESCRIPTION
## Summary
- provide default literal values for function call item type fields so Pydantic can instantiate them without explicit type
- ensure OpenAI compatibility conversion can build function call entries without validation failures

## Testing
- pytest gpt_oss/responses_api -k convert_chat_request

------
https://chatgpt.com/codex/tasks/task_e_68c91e387f2883229744433e1f4ae974